### PR TITLE
fix nginx header to enable CORS + adding auto-restart in case on failure

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -22,17 +22,17 @@ location __PATH__/ {
         return 204;
     }
     if ($request_method = 'POST') {
-        more_set_headers "Access-Control-Allow-Origin: * always";
-        more_set_headers "Access-Control-Allow-Methods: GET, POST, OPTIONS always";
-        more_set_headers "Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range always";
-        more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range always";
+        more_set_headers "Access-Control-Allow-Origin: *";
+        more_set_headers "Access-Control-Allow-Methods: GET, POST, OPTIONS";
+        more_set_headers "Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range";
+        more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
     }
 
     if ($request_method = 'GET') {
-        more_set_headers "Access-Control-Allow-Origin: * always";
-        more_set_headers "Access-Control-Allow-Methods: GET, POST, OPTIONS always";
-        more_set_headers "Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range always";
-        more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range always";
+        more_set_headers "Access-Control-Allow-Origin: *";
+        more_set_headers "Access-Control-Allow-Methods: GET, POST, OPTIONS";
+        more_set_headers "Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range";
+        more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
     }
 
     # this is needed if you have file import via upload enabled

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -12,6 +12,11 @@ Environment="UVICORN_ROOT_PATH=__PATH__"
 
 ExecStart=__INSTALL_DIR__/venv/bin/gunicorn --config __INSTALL_DIR__/gunicorn.conf.py FastAPIAppFolder:app --worker-class uvicorn.workers.UvicornWorker
 
+Restart=on-failure
+RestartSec=1s
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=__APP__-server


### PR DESCRIPTION
## Problem
CORS didn't work anymore since previous change on nginx.conf file, and changing to command 'more_set_headers'

And during my application's usage, I found myself wanting the application to restart automatically in case of Out Of Memory crash

## Solution
Fixing nginx.conf file
Adding Restart properties in the systemd.service file

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
